### PR TITLE
feat: add duplicate detection

### DIFF
--- a/.github/agent-triage.yml
+++ b/.github/agent-triage.yml
@@ -15,6 +15,7 @@ labels:
   github-api: medium
   maintenance: light
   stale: light
+  duplicate: muted
   good-first-issue: muted
   help-wanted: muted
 
@@ -32,6 +33,12 @@ rules:
 
 reactions:
   start: eyes
+
+duplicates:
+  enabled: true
+  threshold: 0.8
+  label: duplicate
+  comment: true
 
 ignore:
   users: [dependabot, renovate]


### PR DESCRIPTION
## summary
- detects duplicate issues using ai
- configurable via yaml
- comments linking to potential duplicate
- optionally adds label

## config options
```yaml
duplicates:
  enabled: true      # toggle on/off
  threshold: 0.8     # confidence required (0-1)
  label: duplicate   # label to add (optional)
  comment: true      # comment with duplicate link
```

## how it works
1. fetches recent open issues
2. ai compares new issue against them
3. if confidence > threshold, comments and labels
4. skips normal triage if duplicate found