### PR TITLE
fix: zod v4 record syntax

### DIFF
--- a/.github/scripts/validate.ts
+++ b/.github/scripts/validate.ts
@@ -5,8 +5,8 @@ import { readFileSync, existsSync } from 'fs'
 const schema = z.object({
   confidence: z.number().min(0).max(1).optional(),
   theme: z.string().optional(),
-  themes: z.record(z.record(z.string())).optional(),
-  labels: z.record(z.string()).optional(),
+  themes: z.record(z.string(), z.record(z.string(), z.string())).optional(),
+  labels: z.record(z.string(), z.string()).optional(),
   rules: z.array(z.object({
     match: z.string(),
     add: z.array(z.string())


### PR DESCRIPTION
z.record() in zod v4 requires both key and value types