### PR TITLE
fix: include workflows and lib in vercel build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "functions": {
     "api/webhook.ts": {
       "maxDuration": 60,
-      "includeFiles": "src/**"
+      "includeFiles": "{src,lib,workflows}/**"
     }
   }
 }


### PR DESCRIPTION
## summary
- add workflows and lib folders to vercel function bundle
- fixes module not found error on webhook endpoint