### PR TITLE
fix: add outputFileTracingIncludes for webhook

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,10 @@
 import type { NextConfig } from "next";
 import { withWorkflow } from "workflow/next";
 
-const config: NextConfig = {};
+const config: NextConfig = {
+	outputFileTracingIncludes: {
+		"/api/webhook": ["./workflows/**", "./lib/**"],
+	},
+};
 
 export default withWorkflow(config);


### PR DESCRIPTION
## summary
- use next.js outputFileTracingIncludes to bundle workflows and lib