### PR TITLE
fix: move webhook to app router for proper bundling

### DIFF
--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -5,10 +5,10 @@ import { SignJWT, importPKCS8 } from 'jose'
 import { parse } from 'yaml'
 import { start } from 'workflow/api'
 import { getWorld } from 'workflow/runtime'
-import { stalechecker } from '../workflows/stale'
-import { sentimentchecker } from '../workflows/sentiment'
-import { getstalerunid, setstalerunid, deletestalerunid, getsentimentrunid, setsentimentrunid, deletesentimentrunid } from '../lib/redis'
-import { fetchpaginated } from '../lib/github'
+import { stalechecker } from '@/workflows/stale'
+import { sentimentchecker } from '@/workflows/sentiment'
+import { getstalerunid, setstalerunid, deletestalerunid, getsentimentrunid, setsentimentrunid, deletesentimentrunid } from '@/lib/redis'
+import { fetchpaginated } from '@/lib/github'
 
 type StaleCheckerArgs = [number, string, string, string, string]
 type SentimentCheckerArgs = [number, string, string, string, string]

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,6 @@
 import type { NextConfig } from "next";
 import { withWorkflow } from "workflow/next";
 
-const config: NextConfig = {
-	outputFileTracingIncludes: {
-		"/api/webhook": ["./workflows/**", "./lib/**"],
-	},
-};
+const config: NextConfig = {};
 
 export default withWorkflow(config);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "compilerOptions": {
+    // Path aliases
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
     // Environment setup & latest features
     "lib": [
       "ESNext",

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,8 @@
 {
   "framework": "nextjs",
   "functions": {
-    "api/webhook.ts": {
-      "maxDuration": 60,
-      "includeFiles": ["src/**", "lib/**", "workflows/**"]
+    "app/api/webhook/route.ts": {
+      "maxDuration": 60
     }
   }
 }


### PR DESCRIPTION
## summary
- move webhook from pages router (api/) to app router (app/api/webhook/)
- use @/ path alias for imports
- withWorkflow handles bundling automatically for app router