### PR TITLE
fix: use smee-client instead of smee in setup docs

### DIFF
--- a/handbook/setup.md
+++ b/handbook/setup.md
@@ -45,7 +45,7 @@ bun run dev
 ```
 
 ```bash
-npx smee -u https://smee.io/<your-channel-id> -t http://localhost:3000/api/webhook
+npx smee-client -u https://smee.io/<your-channel-id> -t http://localhost:3000/api/webhook
 ```
 
 use smee's "resend" feature to re-send webhooks when debugging instead of creating new issues/prs.


### PR DESCRIPTION
## summary
- fix smee cli package name from `smee` to `smee-client`

closes #63