### PR TITLE
chore: switch default model to openai/gpt-5-nano

### DIFF
--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -52,7 +52,7 @@ interface Config {
 
 const defaultconfig: Config = {
 	confidence: 0.6,
-	model: "anthropic/claude-sonnet-4",
+	model: "openai/gpt-5-nano",
 }
 
 async function getconfig(gh: Gh): Promise<Config> {

--- a/app/docs/config/page.tsx
+++ b/app/docs/config/page.tsx
@@ -49,9 +49,9 @@ export default function Config() {
             </h3>
             <p className="text-white/60 mb-4">
               AI model to use for classification. Default:
-              anthropic/claude-sonnet-4
+              openai/gpt-5-nano
             </p>
-            <Codeinline>model: anthropic/claude-sonnet-4</Codeinline>
+            <Codeinline>model: openai/gpt-5-nano</Codeinline>
           </div>
         </div>
       </Section>


### PR DESCRIPTION
## summary
- switch default model from anthropic/claude-sonnet-4 to openai/gpt-5-nano
- update docs to match