### PR TITLE
chore: switch default model to google/gemini-2.5-flash

### DIFF
--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -52,7 +52,7 @@ interface Config {
 
 const defaultconfig: Config = {
 	confidence: 0.6,
-	model: "openai/gpt-5-nano",
+	model: "google/gemini-2.5-flash",
 }
 
 async function getconfig(gh: Gh): Promise<Config> {

--- a/app/docs/config/page.tsx
+++ b/app/docs/config/page.tsx
@@ -49,9 +49,9 @@ export default function Config() {
             </h3>
             <p className="text-white/60 mb-4">
               AI model to use for classification. Default:
-              openai/gpt-5-nano
+              google/gemini-2.5-flash
             </p>
-            <Codeinline>model: openai/gpt-5-nano</Codeinline>
+            <Codeinline>model: google/gemini-2.5-flash</Codeinline>
           </div>
         </div>
       </Section>


### PR DESCRIPTION
## summary
- switch default model from openai/gpt-5-nano to google/gemini-2.5-flash
- update docs to match