### PR TITLE
chore: switch default model to openai/gpt-5-nano

### DIFF
--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -52,7 +52,7 @@ interface Config {
 
 const defaultconfig: Config = {
 	confidence: 0.6,
-	model: "google/gemini-2.5-flash",
+	model: "openai/gpt-5-nano",
 }
 
 async function getconfig(gh: Gh): Promise<Config> {

--- a/app/docs/config/page.tsx
+++ b/app/docs/config/page.tsx
@@ -49,9 +49,9 @@ export default function Config() {
             </h3>
             <p className="text-white/60 mb-4">
               AI model to use for classification. Default:
-              google/gemini-2.5-flash
+              openai/gpt-5-nano
             </p>
-            <Codeinline>model: google/gemini-2.5-flash</Codeinline>
+            <Codeinline>model: openai/gpt-5-nano</Codeinline>
           </div>
         </div>
       </Section>


### PR DESCRIPTION
## summary
- switch default model from google/gemini-2.5-flash to openai/gpt-5-nano
- update docs to match