### PR TITLE
fix: don't remove correct labels during wrong command

### DIFF
--- a/app/api/webhook/feedback.ts
+++ b/app/api/webhook/feedback.ts
@@ -76,8 +76,12 @@ async function handlewrong(
   const ailabels = result.labels;
   const existing = current.data.map(l => l.name);
 
+  const lowercorrect = correctlabels.map(l => l.toLowerCase());
   for (const label of ailabels) {
-    if (existing.includes(label)) {
+    if (
+      existing.includes(label) &&
+      !lowercorrect.includes(label.toLowerCase())
+    ) {
       await gh.octokit.rest.issues.removeLabel({
         owner: gh.owner,
         repo: gh.repo,


### PR DESCRIPTION
## summary
- skip removing ai labels that overlap with the correct labels the user specified
- prevents bug where `@tigent wrong, should be bug, p1` would remove `bug` then re-add it