### PR TITLE
fix: learn from #89 correction

### DIFF
--- a/.github/tigent.yml
+++ b/.github/tigent.yml
@@ -1,6 +1,5 @@
 confidence: 0.6
 theme: mono
-
 labels:
   bug: critical
   security: critical
@@ -17,31 +16,35 @@ labels:
   duplicate: muted
   good-first-issue: muted
   help-wanted: muted
-
 rules:
-  - match: 'crash|broken|not working'
-    add: [bug, p1]
-  - match: 'security|vulnerability|cve'
-    add: [security, p0]
-  - match: 'docs|readme|typo'
-    add: [documentation]
-  - match: 'config|yaml|yml'
-    add: [config]
-  - match: 'webhook|payload'
-    add: [webhook]
-
+  - match: crash|broken|not working
+    add:
+      - bug
+      - p1
+  - match: security|vulnerability|cve
+    add:
+      - security
+      - p0
+  - match: docs|readme|typo
+    add:
+      - documentation
+  - match: config|yaml|yml
+    add:
+      - config
+  - match: webhook|payload
+    add:
+      - webhook
 reactions:
   start: eyes
-
 duplicates:
   enabled: true
   threshold: 0.8
   label: duplicate
   comment: true
-
 ignore:
-  users: [dependabot, renovate]
-
+  users:
+    - dependabot
+    - renovate
 autorespond:
   enabled: true
   label: needs-info
@@ -60,20 +63,22 @@ autorespond:
       - clear description
   message: |
     thanks for opening this issue! we need a bit more info to help you.
-
 stale:
   enabled: true
   days: 30
   close: 7
   exempt:
-    labels: [security, p0, p1]
+    labels:
+      - security
+      - p0
+      - p1
     assignees: true
   label: stale
-  message: |
-    this issue has been inactive for 30 days and will be closed in 7 days if there is no activity.
+  message: >
+    this issue has been inactive for 30 days and will be closed in 7 days if
+    there is no activity.
   closemessage: |
     closed due to inactivity. feel free to reopen if still relevant.
-
 sentiment:
   enabled: true
   detect:
@@ -105,5 +110,11 @@ sentiment:
         apologies for the delay - the team has been notified.
   threshold: 0.7
   exempt:
-    labels: [wontfix, duplicate]
+    labels:
+      - wontfix
+      - duplicate
     users: []
+examples:
+  - title: memory leak in websocket connections
+    labels:
+      - enhancement


### PR DESCRIPTION
adds example to `.github/tigent.yml` from issue #89 correction.

```yaml
- title: "memory leak in websocket connections"
  labels: [enhancement]
```