### PR TITLE
fix: add button type prop

### DIFF
--- a/app/docs/components.tsx
+++ b/app/docs/components.tsx
@@ -120,6 +120,7 @@ export function Code({
   return (
     <div className={`relative group/code ${className}`}>
       <button
+        type="button"
         onClick={copy}
         className={`absolute top-4 right-4 p-2 rounded-lg transition-all ${
           copied


### PR DESCRIPTION
## summary
- add type="button" to copy button in code component
- fixes biome a11y/useButtonType lint warning