### PR TITLE
fix: preserve literal block style for prompt in yaml

### DIFF
--- a/app/api/webhook/learn.ts
+++ b/app/api/webhook/learn.ts
@@ -78,7 +78,7 @@ export async function createpr(
     .split('\n')
     .map(l => `  ${l}`)
     .join('\n');
-  const yaml = `${rest}prompt: |\n${promptlines}\n`;
+  const yaml = `${rest}\nprompt: |\n${promptlines}\n`;
 
   await dancer.rest.repos.createOrUpdateFileContents({
     owner: gh.owner,


### PR DESCRIPTION
## summary
- manually build yaml to keep prompt as literal block style (|)
- prevents yaml stringify from reformatting to folded style (>-)