### PR TITLE
fix: don't add trailing spaces to blank lines in yaml

### DIFF
--- a/app/api/webhook/learn.ts
+++ b/app/api/webhook/learn.ts
@@ -76,7 +76,7 @@ export async function createpr(
   const rest = Object.keys(fileconfig).length > 0 ? stringify(fileconfig) : '';
   const promptlines = newprompt
     .split('\n')
-    .map(l => `  ${l}`)
+    .map(l => (l ? `  ${l}` : ''))
     .join('\n');
   const yaml = `${rest}\nprompt: |\n${promptlines}\n`;
 


### PR DESCRIPTION
## summary
- skip indentation on empty lines in prompt yaml output