### PR TITLE
fix: trim before matching should be in parselabels

### DIFF
--- a/app/api/webhook/feedback.ts
+++ b/app/api/webhook/feedback.ts
@@ -117,6 +117,7 @@ async function handlewrong(
 function parselabels(input: string): string[] {
   const cleaned = input
     .replace(/^,/, '')
+    .trim()
     .replace(/^should be/i, '')
     .trim();
   if (!cleaned) return [];


### PR DESCRIPTION
## summary
- add trim between comma removal and "should be" regex so it matches correctly
- fixes support and other labels being swallowed into "should be X" as one string