### PR TITLE
fix: migrate generateObject to generateText with Output.object

### DIFF
--- a/app/api/webhook/feedback.ts
+++ b/app/api/webhook/feedback.ts
@@ -1,4 +1,4 @@
-import { generateObject } from 'ai';
+import { generateText, Output } from 'ai';
 import { z } from 'zod';
 import type { Gh, Config } from './triage';
 import { classify, fetchlabels, addlabels } from './triage';
@@ -15,9 +15,9 @@ async function parseintent(
   comment: string,
   available: string[],
 ) {
-  const { object } = await generateObject({
+  const { output } = await generateText({
     model: config.model,
-    schema: intentschema,
+    output: Output.object({ schema: intentschema }),
     system: `you parse commands directed at a github issue labeling bot called tigent.
 
 classify the intent:
@@ -34,7 +34,7 @@ rules:
 - only include labels that exist in the available labels list.`,
     prompt: comment,
   });
-  return object;
+  return output!;
 }
 
 export async function handlecomment(gh: Gh, config: Config, payload: any) {

--- a/app/api/webhook/triage.ts
+++ b/app/api/webhook/triage.ts
@@ -1,4 +1,4 @@
-import { generateObject } from 'ai';
+import { generateText, Output } from 'ai';
 import { z } from 'zod';
 import { parse } from 'yaml';
 import type { Octokit } from 'octokit';
@@ -109,17 +109,17 @@ rules:
 body:
 ${body || 'no description'}${extra ? `\n\n${extra}` : ''}`;
 
-  const { object } = await generateObject({
+  const { output } = await generateText({
     model: config.model,
-    schema,
+    output: Output.object({ schema }),
     system,
     prompt,
   });
-  const valid = object.labels.filter(l => labels.some(x => x.name === l));
+  const valid = output!.labels.filter(l => labels.some(x => x.name === l));
   return {
     labels: valid,
-    confidence: object.confidence,
-    reasoning: object.reasoning,
+    confidence: output!.confidence,
+    reasoning: output!.reasoning,
   };
 }
 


### PR DESCRIPTION
## summary
- replace deprecated generateObject with generateText + Output.object
- updated in triage.ts (classify) and feedback.ts (parseintent)