### PR TITLE
fix: replace users config with role-based auth

### DIFF
--- a/.github/scripts/validate.ts
+++ b/.github/scripts/validate.ts
@@ -6,7 +6,6 @@ const schema = z.object({
   confidence: z.number().min(0).max(1).optional(),
   model: z.string().optional(),
   prompt: z.string().optional(),
-  users: z.array(z.string()).optional(),
 });
 
 const configpath = '.github/tigent.yml';

--- a/.github/tigent.yml
+++ b/.github/tigent.yml
@@ -1,13 +1,5 @@
 confidence: 0.6
 
-users:
-  - gr2m
-  - dancer
-  - aayush-kapoor
-  - lgrammel
-  - nicoalbanese
-  - felixarntz
-
 prompt: |
   this bot labels issues and prs for the vercel ai sdk monorepo. the ai sdk provides a unified api for working with large language models across providers.
 

--- a/app/api/webhook/feedback.ts
+++ b/app/api/webhook/feedback.ts
@@ -40,10 +40,9 @@ rules:
 export async function handlecomment(gh: Gh, config: Config, payload: any) {
   const comment = payload.comment;
   const body: string = comment.body?.trim() || '';
-  const username: string = comment.user?.login || '';
+  const association: string = comment.author_association || '';
 
-  if (!config.users.some(u => u.toLowerCase() === username.toLowerCase()))
-    return;
+  if (!['OWNER', 'MEMBER', 'COLLABORATOR'].includes(association)) return;
   if (!body.toLowerCase().startsWith('@tigent')) return;
 
   await reactcomment(gh, comment.id);

--- a/app/api/webhook/triage.ts
+++ b/app/api/webhook/triage.ts
@@ -13,7 +13,6 @@ export interface Config {
   confidence: number;
   model: string;
   prompt: string;
-  users: string[];
 }
 
 export interface Label {
@@ -25,7 +24,6 @@ export const defaultconfig: Config = {
   confidence: 0.6,
   model: 'openai/gpt-5-nano',
   prompt: '',
-  users: [],
 };
 
 export async function getconfig(gh: Gh): Promise<Config> {

--- a/app/docs/config/page.tsx
+++ b/app/docs/config/page.tsx
@@ -94,36 +94,9 @@ export default function Config() {
         </div>
       </Section>
 
-      <Section id="users" title="Users">
-        <div className="space-y-8 max-w-2xl">
-          <div>
-            <h3
-              id="users-option"
-              className="text-lg font-semibold mb-2 text-white"
-            >
-              users
-            </h3>
-            <p className="text-white/60 mb-4">
-              List of GitHub usernames allowed to use feedback commands (@tigent
-              why, @tigent wrong). Only users in this list can interact with
-              Tigent. If no users are configured, feedback commands are
-              disabled.
-            </p>
-            <Code className="max-w-2xl">{`users:
-  - gr2m
-  - aayush-kapoor
-  - dancer`}</Code>
-          </div>
-        </div>
-      </Section>
-
       <Section id="example" title="Full example">
         <p className="text-white/60 mb-6 max-w-2xl">A complete config file:</p>
         <Code className="max-w-2xl">{`confidence: 0.7
-
-users:
-  - gr2m
-  - aayush-kapoor
 
 prompt: |
   crashes and errors are always bug.

--- a/app/docs/feedback/page.tsx
+++ b/app/docs/feedback/page.tsx
@@ -75,9 +75,8 @@ prompt: |
 
       <Section id="permissions" title="Permissions">
         <p className="text-white/60 max-w-2xl">
-          Only users listed in the users config can use feedback commands.
-          Comments from other users are ignored. If no users are configured,
-          feedback commands are disabled.
+          Only repository owners, members, and collaborators can use feedback
+          commands. Comments from other users are ignored.
         </p>
       </Section>
 


### PR DESCRIPTION
## summary
- remove users config field
- use github author_association (owner, member, collaborator) for feedback commands
- works on any repo without needing to list usernames
- update docs and validation schema