### PR TITLE
fix: mention ai sdk deployment and customization in docs

### DIFF
--- a/app/docs/config/page.tsx
+++ b/app/docs/config/page.tsx
@@ -19,12 +19,18 @@ export default function Config() {
         <p className="text-white/60 mb-4 max-w-2xl">
           Tigent works out of the box with no configuration. It reads your
           existing labels and their descriptions to determine how to classify
-          issues and PRs.
+          issues and PRs. The default setup is configured for the Vercel AI SDK
+          repository.
         </p>
-        <p className="text-white/60 max-w-2xl">
-          If you want to customize the behavior, create a config file at:
+        <p className="text-white/60 mb-4 max-w-2xl">
+          To customize for your own repo, create a config file at:
         </p>
         <Codeinline className="mt-4">.github/tigent.yml</Codeinline>
+        <p className="text-white/60 mt-4 max-w-2xl">
+          The most important field is the prompt. Write rules that describe how
+          your labels should be applied. Tigent reads your labels from GitHub at
+          runtime, so the prompt just needs to explain when to use each one.
+        </p>
       </Section>
 
       <Section id="options" title="Options">

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -20,11 +20,12 @@ export default function Docs() {
         <p className="text-white/60 mb-4 max-w-2xl">
           Tigent reads your existing GitHub labels and their descriptions, then
           uses AI to automatically apply the right labels when issues or PRs are
-          opened.
+          opened. Currently deployed on the Vercel AI SDK repository.
         </p>
         <p className="text-white/60 max-w-2xl">
-          No complex configuration needed. Just install the app and add
-          descriptions to your labels in GitHub settings.
+          Works on any repo. Install the app, add a prompt to customize labeling
+          for your project, and correct mistakes with natural language comments
+          to teach it over time.
         </p>
       </Section>
 

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,15 @@
   3. ai picks matching labels
   4. applies labels if confidence > 0.6
 
+> currently deployed on?
+
+  vercel/ai (ai sdk)
+
+> works on other repos?
+
+  yes. install the app and add a .github/tigent.yml
+  with a prompt tailored to your labels and workflow.
+
 > stack?
 
   ai sdk · ai gateway · github app · vercel · octokit


### PR DESCRIPTION
## summary
- update readme to mention vercel/ai deployment and how to use on other repos
- update intro page to mention ai sdk and customization
- update config page to explain prompt customization for other repos