### PR TITLE
fix: generate general rules instead of issue-specific ones

### DIFF
--- a/app/api/webhook/learn.ts
+++ b/app/api/webhook/learn.ts
@@ -10,7 +10,7 @@ const dancer = process.env.DANCER_PAT
 async function lesson(context: string, model: string): Promise<string> {
   const { text } = await generateText({
     model,
-    system: `you write a single short rule for a github issue labeling bot based on a correction. output one line only, no bullets or prefixes. example: "issues about improving existing structured output support are enhancement, not feature."`,
+    system: `you extract a general labeling rule from a correction. do not reference the specific issue, title, or provider name. focus on the pattern: what kind of issue was it and why were the original labels wrong. output one line only, no bullets or prefixes. example: "when a user is confused about how something works, use support instead of bug."`,
     prompt: context,
   });
   return text.trim();


### PR DESCRIPTION
## summary
- update lesson prompt to extract general patterns, not issue-specific rules
- prevents rules like "switching to google provider is support" in favor of "user confusion is support, not bug"