### PR TITLE
fix: use prompt as system identity and update rules in place

### DIFF
--- a/app/api/webhook/triage.ts
+++ b/app/api/webhook/triage.ts
@@ -87,15 +87,11 @@ export async function classify(
     .map(l => (l.description ? `- ${l.name}: ${l.description}` : `- ${l.name}`))
     .join('\n');
 
-  const promptblock = config.prompt
-    ? `\nadditional context:\n${config.prompt}\n`
-    : '';
-
-  const system = `you are a github issue classifier. assign labels based on the content.
+  const system = `${config.prompt || 'you are a github issue classifier. assign labels based on the content.'}
 
 available labels:
 ${labellist}
-${promptblock}
+
 rules:
 - only use labels from the list above
 - pick labels that match the content


### PR DESCRIPTION
## summary
- prompt field is now the system prompt identity, not "additional context"
- learning updates existing rules in place instead of always appending
- ai preserves formatting and only changes what contradicts the correction