### PR TITLE
feat: remove confidence, switch to gemini flash, increase timeout

### DIFF
--- a/.github/scripts/validate.ts
+++ b/.github/scripts/validate.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import { readFileSync, existsSync } from 'fs';
 
 const schema = z.object({
-  confidence: z.number().min(0).max(1).optional(),
   model: z.string().optional(),
   prompt: z.string().optional(),
 });

--- a/.github/tigent.yml
+++ b/.github/tigent.yml
@@ -1,64 +1,60 @@
-confidence: 0.6
-
 prompt: |
-  this bot labels issues and prs for the vercel ai sdk monorepo. the ai sdk provides a unified api for working with large language models across providers.
+  you are the labeling agent for the vercel ai sdk repository. your job is to read every new issue and pr and apply the correct labels. always apply labels, never skip.
 
-  area labels (assign one or more based on which package is affected):
-  ai/core is for the core generateText, generateObject, streamText, streamObject apis, tool calling, structured output, steps, middleware, telemetry hooks, and anything in the ai package that isn't ui-related.
-  ai/ui is for useChat, useCompletion, useAssistant, UIMessage, ui message streaming, react hooks, and frontend integration. also covers angular and svelte ui bindings.
-  ai/ui-vue is specifically for vue.js ui bindings.
-  ai/rsc is for react server components integration, createStreamableUI, createStreamableValue, and server action streaming.
-  ai/provider is for the provider interface, provider registry, model specifications, and shared provider utilities. use this when the issue is about how providers implement the ai sdk interface.
-  ai/mcp is for model context protocol integration, mcp client, mcp server tools, and @ai-sdk/mcp.
-  ai/gateway is for the ai gateway (@ai-sdk/gateway), provider routing, oidc auth, and the vercel ai gateway service.
-  ai/telemetry is for opentelemetry integration, tracing, span attributes, and observability.
-  ai/codemod is for codemods, migration scripts, and automated code transformations between sdk versions.
-  expo is for react native and expo-specific issues, metro bundler compatibility, and mobile platform concerns.
-  tools-registry is for the tools registry, tool packages, and shared tool definitions.
-  codex is for codex-related functionality.
+  the ai sdk is a monorepo with packages for core ai functionality, ui hooks, provider integrations, mcp, gateway, and more. most issues come from users who need help, not from actual bugs.
 
-  provider labels (assign when the issue is specific to a provider):
-  provider/openai for openai and gpt models. provider/anthropic for anthropic and claude models. provider/google for google ai and gemini models. provider/google-vertex for google vertex ai. provider/azure for azure openai. provider/amazon-bedrock for aws bedrock. provider/xai for xai/grok. provider/mistral for mistral. provider/cohere for cohere. provider/groq for groq. provider/deepseek for deepseek. provider/fireworks for fireworks. provider/togetherai for together ai. provider/perplexity for perplexity. provider/replicate for replicate. provider/huggingface for hugging face. provider/cerebras for cerebras. provider/deepinfra for deepinfra. provider/baseten for baseten. provider/fal for fal. provider/luma for luma. provider/black-forest-labs for bfl/flux image models. provider/gateway for the gateway provider specifically. provider/vercel for the vercel provider.
-  provider/openai-compatible is for issues with providers using the openai-compatible base layer.
-  provider/community is for community-maintained providers not officially supported.
-  provider labels for audio/speech: provider/elevenlabs, provider/lmnt, provider/hume, provider/deepgram, provider/assemblyai, provider/gladia, provider/revai.
+  when in doubt, add support. if someone says "doesn't work" or "how do i", that's support not bug. only use bug when there's a clear defect or regression with evidence.
+
+  every issue should get at least one area label and one type label.
+
+  area labels:
+  ai/core — generateText, generateObject, streamText, streamObject, tool calling, structured output, steps, middleware.
+  ai/ui — useChat, useCompletion, useAssistant, UIMessage, react hooks, frontend streaming.
+  ai/ui-vue — vue.js ui bindings.
+  ai/rsc — react server components, createStreamableUI, createStreamableValue.
+  ai/provider — provider interface, registry, model specs, shared utilities.
+  ai/mcp — model context protocol, @ai-sdk/mcp, mcp tools.
+  ai/gateway — @ai-sdk/gateway, provider routing, oidc.
+  ai/telemetry — opentelemetry, tracing, spans.
+  ai/codemod — codemods, migration scripts.
+  expo — react native, expo, metro bundler.
+  tools-registry — tool packages, shared tool definitions.
+  codex — codex functionality.
+
+  provider labels (use alongside ai/provider):
+  provider/openai, provider/anthropic, provider/google, provider/google-vertex, provider/azure, provider/amazon-bedrock, provider/xai, provider/mistral, provider/cohere, provider/groq, provider/deepseek, provider/fireworks, provider/togetherai, provider/perplexity, provider/replicate, provider/huggingface, provider/cerebras, provider/deepinfra, provider/baseten, provider/fal, provider/luma, provider/black-forest-labs, provider/gateway, provider/vercel.
+  provider/openai-compatible — providers using the openai-compatible base.
+  provider/community — community-maintained providers.
+  audio/speech providers: provider/elevenlabs, provider/lmnt, provider/hume, provider/deepgram, provider/assemblyai, provider/gladia, provider/revai.
 
   type labels:
-  bug is for defects, regressions, unexpected errors, incorrect behavior. look for phrases like "doesn't work", "error", "crash", "regression", "broke", "unexpected".
-  feature is for new capabilities that don't exist yet. look for "feature request", "would be nice", "support for", "add ability to".
-  documentation is for docs improvements, typos, missing guides, incorrect examples, broken links, outdated references.
-  maintenance is for dependency updates, refactoring, ci/cd, tooling, code cleanup, test improvements, normalizing patterns across packages.
-  support is for general questions, help requests, usage guidance, and "how do i" questions. most user-filed issues that aren't clear bugs get support.
-  wontfix should never be assigned by the bot.
-  deprecation is for marking apis, features, or patterns as deprecated in favor of newer alternatives.
+  bug — confirmed defects, regressions, crashes, incorrect behavior.
+  feature — new capabilities that don't exist yet.
+  documentation — docs, typos, missing guides, broken links.
+  maintenance — dependency updates, refactoring, ci/cd, tooling, tests.
+  support — questions, help requests, "how do i", confusion, setup issues. this is the most common label for user-filed issues.
+  deprecation — marking apis or patterns as deprecated.
+  never assign wontfix.
 
   triage labels:
-  reproduction needed means the bug report lacks a minimal reproduction. assign this when someone reports a bug but doesn't include steps to reproduce, a code snippet, or a repo link.
-  reproduction provided means a reproduction has been supplied (code, repo link, or clear steps).
-  pull request welcome marks issues where the team would appreciate community prs. similar to good first issue but can be more complex.
-  good first issue is for small, well-scoped tasks suitable for new contributors.
-  external means the issue is caused by something outside the ai sdk (a provider api change, a framework bug, a user's environment).
-  resumability is for issues related to resumable streams and recovery.
+  reproduction needed — bug report without repro steps or code.
+  reproduction provided — bug report with code, repo link, or clear steps.
+  good first issue — small well-scoped tasks for new contributors.
+  pull request welcome — tasks where community prs are appreciated.
+  external — issue caused by something outside the ai sdk.
+  resumability — resumable streams and recovery.
 
-  version labels:
-  major marks prs that include breaking changes requiring a major version bump.
-  minor marks prs that add new features requiring a minor version bump.
-  backport marks prs that should be backported to older release branches.
+  version labels (prs only):
+  major — breaking changes. minor — new features. backport — should be backported.
 
   workflow labels:
-  type:batch is for coordinated changes across multiple packages.
-  type:epic is for large tracked initiatives spanning multiple prs.
+  type:batch — coordinated changes across packages.
+  type:epic — large tracked initiatives.
 
-  labeling patterns observed in this repo:
-  most issues get an area label (ai/core, ai/ui, ai/provider) plus support. bugs also get bug. provider-specific issues get both ai/provider and the specific provider label (e.g., provider/anthropic).
-  prs typically get area labels matching what they change, plus bug or feature or documentation as the type.
-  issues mentioning streaming, generateText, generateObject, streamText, streamObject, tool calling, structured output, steps, or middleware are ai/core.
-  issues mentioning useChat, useCompletion, hooks, or frontend are ai/ui.
-  issues about a specific provider's behavior (model responses, api compatibility, token counting) get both ai/provider and the provider label.
-  issues about the gateway, routing, or oidc get ai/gateway.
-  issues about mcp servers, mcp tools, or model context protocol get ai/mcp.
-  docs prs that only touch documentation files get documentation alone.
-  dependency update prs get maintenance.
-  if an issue mentions both a bug and a provider, assign bug + ai/provider + the provider label.
-  if someone asks "how do i" or "is it possible to", that's support plus the relevant area.
-  do not assign labels you are not confident about. under-labeling is better than mislabeling.
+  patterns:
+  user says "error" or "doesn't work" but is asking how to use something → support, not bug.
+  provider-specific issues get ai/provider + the specific provider label.
+  issues about streaming, generateText, tool calling → ai/core.
+  issues about useChat, useCompletion, hooks → ai/ui.
+  docs-only prs → documentation.
+  dependency updates → maintenance.

--- a/app/api/webhook/feedback.ts
+++ b/app/api/webhook/feedback.ts
@@ -71,7 +71,7 @@ export async function handlecomment(gh: Gh, config: Config, payload: any) {
 async function handlewhy(gh: Gh, config: Config, issue: any, labels: any[]) {
   const result = await classify(config, labels, issue.title, issue.body || '');
   const labelstr = result.labels.join(', ');
-  const body = `**labels:** ${labelstr}\n**confidence:** ${result.confidence}\n\n${result.reasoning}`;
+  const body = `**labels:** ${labelstr}\n\n${result.reasoning}`;
 
   await gh.octokit.rest.issues.createComment({
     owner: gh.owner,

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -33,6 +33,8 @@ app.webhooks.on('issue_comment.created', async ({ octokit, payload }) => {
   await handlecomment(gh, config, payload);
 });
 
+export const maxDuration = 300;
+
 export async function POST(req: Request) {
   const body = await req.text();
   try {

--- a/app/api/webhook/triage.ts
+++ b/app/api/webhook/triage.ts
@@ -10,7 +10,6 @@ export interface Gh {
 }
 
 export interface Config {
-  confidence: number;
   model: string;
   prompt: string;
 }
@@ -21,8 +20,7 @@ export interface Label {
 }
 
 export const defaultconfig: Config = {
-  confidence: 0.6,
-  model: 'openai/gpt-5-nano',
+  model: 'google/gemini-2.5-flash',
   prompt: '',
 };
 
@@ -72,7 +70,6 @@ export async function react(gh: Gh, issue: number) {
 
 export const schema = z.object({
   labels: z.array(z.string()),
-  confidence: z.number().min(0).max(1),
   reasoning: z.string(),
 });
 
@@ -112,7 +109,6 @@ ${body || 'no description'}${extra ? `\n\n${extra}` : ''}`;
   const valid = output!.labels.filter(l => labels.some(x => x.name === l));
   return {
     labels: valid,
-    confidence: output!.confidence,
     reasoning: output!.reasoning,
   };
 }
@@ -136,9 +132,7 @@ export async function triageissue(gh: Gh, config: Config, number: number) {
     issue.data.body || '',
   );
 
-  if (result.confidence >= config.confidence && result.labels.length > 0) {
-    await addlabels(gh, number, result.labels);
-  }
+  await addlabels(gh, number, result.labels);
 }
 
 export async function triagepr(gh: Gh, config: Config, number: number) {
@@ -170,7 +164,5 @@ export async function triagepr(gh: Gh, config: Config, number: number) {
     extra,
   );
 
-  if (result.confidence >= config.confidence && result.labels.length > 0) {
-    await addlabels(gh, number, result.labels);
-  }
+  await addlabels(gh, number, result.labels);
 }

--- a/app/docs/config/page.tsx
+++ b/app/docs/config/page.tsx
@@ -36,36 +36,15 @@ export default function Config() {
       <Section id="options" title="Options">
         <div className="space-y-8 max-w-2xl">
           <div>
-            <h3
-              id="confidence"
-              className="text-lg font-semibold mb-2 text-white"
-            >
-              confidence
-            </h3>
-            <p className="text-white/60 mb-4">
-              When Tigent classifies an issue or PR, the AI returns a confidence
-              score between 0.0 and 1.0. Labels are only applied if the score
-              meets or exceeds this threshold. If the AI is unsure, the issue is
-              left unlabeled rather than mislabeled.
-            </p>
-            <p className="text-white/60 mb-4">
-              Lower values (0.3 - 0.5) label more issues but with less accuracy.
-              Higher values (0.7 - 0.9) are more conservative and only label
-              when the AI is highly confident. Default: 0.6
-            </p>
-            <Codeinline>confidence: 0.7</Codeinline>
-          </div>
-
-          <div>
             <h3 id="model" className="text-lg font-semibold mb-2 text-white">
               model
             </h3>
             <p className="text-white/60 mb-4">
               AI model to use for classification. Tigent uses the AI SDK gateway
               format, so you can use any supported provider and model. Default:
-              openai/gpt-5-nano
+              google/gemini-2.5-flash
             </p>
-            <Codeinline>model: openai/gpt-5-nano</Codeinline>
+            <Codeinline>model: google/gemini-2.5-flash</Codeinline>
           </div>
         </div>
       </Section>
@@ -102,11 +81,11 @@ export default function Config() {
 
       <Section id="example" title="Full example">
         <p className="text-white/60 mb-6 max-w-2xl">A complete config file:</p>
-        <Code className="max-w-2xl">{`confidence: 0.7
-
-prompt: |
+        <Code className="max-w-2xl">{`prompt: |
+  you are the labeling agent for my project.
   crashes and errors are always bug.
-  feature requests get feature, not enhancement.`}</Code>
+  feature requests get feature, not enhancement.
+  when in doubt, add support.`}</Code>
       </Section>
 
       <Prevnext />

--- a/app/docs/feedback/page.tsx
+++ b/app/docs/feedback/page.tsx
@@ -66,11 +66,10 @@ export default function Feedback() {
           rules. Over time, the prompt becomes a detailed guide tailored to your
           project.
         </p>
-        <Code className="max-w-2xl">{`confidence: 0.7
-
-prompt: |
+        <Code className="max-w-2xl">{`prompt: |
   crashes and errors are always bug.
-  feature requests get feature, not enhancement.`}</Code>
+  feature requests get feature, not enhancement.
+  when in doubt, add support.`}</Code>
       </Section>
 
       <Section id="permissions" title="Permissions">

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -49,9 +49,7 @@ export default function Docs() {
           </div>
           <div className="flex gap-4">
             <span className="text-white/40 font-mono">4</span>
-            <p className="text-white/60">
-              Labels are applied if confidence is above threshold
-            </p>
+            <p className="text-white/60">Labels are applied automatically</p>
           </div>
         </div>
       </Section>


### PR DESCRIPTION
## summary
- remove confidence threshold, always apply labels
- switch default model from openai/gpt-5-nano to google/gemini-2.5-flash
- increase vercel function timeout to 300s
- rewrite tigent.yml prompt as a proper system prompt identity
- update docs to reflect all changes