### PR TITLE
fix: branch collision and stale docs text

### DIFF
--- a/app/api/webhook/learn.ts
+++ b/app/api/webhook/learn.ts
@@ -56,6 +56,14 @@ export async function createpr(
   });
   const sha = ref.object.sha;
 
+  try {
+    await dancer.rest.git.deleteRef({
+      owner: gh.owner,
+      repo: gh.repo,
+      ref: `heads/${branch}`,
+    });
+  } catch {}
+
   await dancer.rest.git.createRef({
     owner: gh.owner,
     repo: gh.repo,

--- a/app/docs/feedback/page.tsx
+++ b/app/docs/feedback/page.tsx
@@ -18,8 +18,8 @@ export default function Feedback() {
       <Section id="commands" title="Commands">
         <p className="text-white/60 mb-6 max-w-2xl">
           Mention @tigent in any comment to interact with it. Tigent uses AI to
-          understand your intent, so you can write naturally. Only users listed
-          in your config can use these commands.
+          understand your intent, so you can write naturally. Only repository
+          owners, members, and collaborators can use these commands.
         </p>
 
         <div className="space-y-8 max-w-2xl">


### PR DESCRIPTION
## summary
- delete existing branch before creating in learn.ts to prevent collision on double correction
- fix feedback docs still saying "users listed in your config"