### PR TITLE
feat: include pr diff in classification context

### DIFF
--- a/app/api/webhook/triage.ts
+++ b/app/api/webhook/triage.ts
@@ -153,8 +153,11 @@ export async function triagepr(gh: Gh, config: Config, number: number) {
     fetchlabels(gh),
   ]);
 
-  const filelist = files.data.map(f => f.filename).join('\n');
-  const extra = `changed files:\n${filelist}`;
+  const parts = files.data.map(f => {
+    const patch = f.patch ? `\n${f.patch}` : '';
+    return `${f.filename} (+${f.additions} -${f.deletions})${patch}`;
+  });
+  const extra = `changed files:\n${parts.join('\n\n')}`;
 
   const result = await classify(
     config,


### PR DESCRIPTION
## summary
- include actual file patches in pr classification, not just filenames
- ai now sees the diff for each changed file with additions/deletions
- better label accuracy since it can read what actually changed