### PR TITLE
feat: split wrong and learn intents, remove any types

### DIFF
--- a/app/api/webhook/feedback.ts
+++ b/app/api/webhook/feedback.ts
@@ -1,11 +1,26 @@
 import { generateText, Output } from 'ai';
 import { z } from 'zod';
-import type { Gh, Config } from './triage';
+import type { Gh, Config, Label } from './triage';
 import { classify, fetchlabels, addlabels } from './triage';
 import { createpr } from './learn';
 
+interface Issue {
+  number: number;
+  title: string;
+  body: string | null;
+}
+
+interface Payload {
+  comment: {
+    id: number;
+    body?: string;
+    author_association?: string;
+  };
+  issue: Issue;
+}
+
 const intentschema = z.object({
-  intent: z.enum(['why', 'wrong', 'unsupported']),
+  intent: z.enum(['why', 'wrong', 'learn', 'unsupported']),
   labels: z.array(z.string()),
   reply: z.string(),
 });
@@ -22,7 +37,8 @@ async function parseintent(
 
 classify the intent:
 - "why": user wants to know why labels were assigned or wants the bot to explain its reasoning.
-- "wrong": user is correcting the labels. extract the correct label names into the labels array. match against available labels (case-insensitive).
+- "wrong": user is correcting the labels. extract the correct label names into the labels array. just fix the labels, do not update rules.
+- "learn": user is correcting labels AND explicitly asking to update the rules or make a pr. look for phrases like "update your rules", "learn this", "make a pr", "fix your prompt", "remember this". extract the correct label names into the labels array.
 - "unsupported": user is asking the bot to do something it cannot do (close, delete, assign, merge, etc). write a short one-sentence reply explaining what tigent can do instead.
 
 available labels: ${available.join(', ')}
@@ -30,14 +46,16 @@ available labels: ${available.join(', ')}
 rules:
 - for "why" intent, labels array should be empty, reply should be empty.
 - for "wrong" intent, extract every label the user mentions. reply should be empty.
+- for "learn" intent, extract every label the user mentions. reply should be empty.
 - for "unsupported" intent, labels array should be empty. reply should be brief and lowercase.
-- only include labels that exist in the available labels list.`,
+- only include labels that exist in the available labels list.
+- default to "wrong" not "learn" unless the user explicitly asks to update rules or learn.`,
     prompt: comment,
   });
   return output!;
 }
 
-export async function handlecomment(gh: Gh, config: Config, payload: any) {
+export async function handlecomment(gh: Gh, config: Config, payload: Payload) {
   const comment = payload.comment;
   const body: string = comment.body?.trim() || '';
   const association: string = comment.author_association || '';
@@ -57,7 +75,9 @@ export async function handlecomment(gh: Gh, config: Config, payload: any) {
   if (intent.intent === 'why') {
     await handlewhy(gh, config, issue, repolabels);
   } else if (intent.intent === 'wrong' && intent.labels.length > 0) {
-    await handlewrong(gh, config, issue, intent.labels, repolabels);
+    await handlewrong(gh, config, issue, intent.labels, repolabels, false);
+  } else if (intent.intent === 'learn' && intent.labels.length > 0) {
+    await handlewrong(gh, config, issue, intent.labels, repolabels, true);
   } else if (intent.intent === 'unsupported' && intent.reply) {
     await gh.octokit.rest.issues.createComment({
       owner: gh.owner,
@@ -68,7 +88,12 @@ export async function handlecomment(gh: Gh, config: Config, payload: any) {
   }
 }
 
-async function handlewhy(gh: Gh, config: Config, issue: any, labels: any[]) {
+async function handlewhy(
+  gh: Gh,
+  config: Config,
+  issue: Issue,
+  labels: Label[],
+) {
   const result = await classify(config, labels, issue.title, issue.body || '');
   const labelstr = result.labels.join(', ');
   const body = `**labels:** ${labelstr}\n\n${result.reasoning}`;
@@ -84,9 +109,10 @@ async function handlewhy(gh: Gh, config: Config, issue: any, labels: any[]) {
 async function handlewrong(
   gh: Gh,
   config: Config,
-  issue: any,
+  issue: Issue,
   correctlabels: string[],
-  repolabels: any[],
+  repolabels: Label[],
+  learn: boolean,
 ) {
   const [result, current] = await Promise.all([
     classify(config, repolabels, issue.title, issue.body || ''),
@@ -129,14 +155,16 @@ async function handlewrong(
     await addlabels(gh, issue.number, matchedlabels);
   }
 
-  await createpr(
-    gh,
-    issue.number,
-    issue.title,
-    matchedlabels,
-    ailabels,
-    config,
-  );
+  if (learn) {
+    await createpr(
+      gh,
+      issue.number,
+      issue.title,
+      matchedlabels,
+      ailabels,
+      config,
+    );
+  }
 }
 
 async function reactcomment(gh: Gh, commentid: number) {


### PR DESCRIPTION
## summary
- split wrong intent: "wrong" just fixes labels, "learn" fixes labels and makes a pr
- pr only created when user explicitly asks to update rules or learn
- replace all any types with proper interfaces