### PR TITLE
feat: rich activity logs with colors

### DIFF
--- a/app/api/webhook/feedback.ts
+++ b/app/api/webhook/feedback.ts
@@ -97,8 +97,11 @@ async function handlewhy(
   labels: Label[],
 ) {
   const result = await classify(config, labels, issue.title, issue.body || '');
-  const labelstr = result.labels.join(', ');
-  const body = `**labels:** ${labelstr}\n\n${result.reasoning}`;
+  const labelstr = result.labels.map(l => l.name).join(', ');
+  const reasons = result.labels
+    .map(l => `- **${l.name}**: ${l.reason}`)
+    .join('\n');
+  const body = `**labels:** ${labelstr}\n\n${reasons}`;
 
   await gh.octokit.rest.issues.createComment({
     owner: gh.owner,
@@ -125,7 +128,7 @@ async function handlewrong(
     }),
   ]);
 
-  const ailabels = result.labels;
+  const ailabels = result.labels.map(l => l.name);
   const existing = current.data.map(l => l.name);
 
   const lowercorrect = correctlabels.map(l => l.toLowerCase());

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -21,7 +21,15 @@ app.webhooks.on('issues.opened', async ({ octokit, payload }) => {
       number: payload.issue.number,
       title: result.title,
       labels: result.labels,
-      reasoning: result.reasoning,
+      rejected: result.rejected,
+      confidence: result.confidence,
+      summary: result.summary,
+      model: config.model,
+      duration: result.duration,
+      author: result.author,
+      url: result.url,
+      skipped: result.skipped,
+      available: result.available,
     });
   } catch {
     await react(gh, payload.issue.number, 'confused');
@@ -40,7 +48,15 @@ app.webhooks.on('pull_request.opened', async ({ octokit, payload }) => {
       number: payload.pull_request.number,
       title: result.title,
       labels: result.labels,
-      reasoning: result.reasoning,
+      rejected: result.rejected,
+      confidence: result.confidence,
+      summary: result.summary,
+      model: config.model,
+      duration: result.duration,
+      author: result.author,
+      url: result.url,
+      skipped: result.skipped,
+      available: result.available,
     });
   } catch {
     await react(gh, payload.pull_request.number, 'confused');

--- a/app/dashboard/[owner]/[repo]/page.tsx
+++ b/app/dashboard/[owner]/[repo]/page.tsx
@@ -12,7 +12,7 @@ export default function Page() {
     <div className="p-10 space-y-8 min-w-0">
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
-        <p className="text-muted mt-1">{full}</p>
+        <p className="text-muted mt-1 capitalize">{full}</p>
       </div>
       <Activity repo={full} />
       <Config repo={params.repo} owner={params.owner} />

--- a/app/dashboard/components/sidebar.tsx
+++ b/app/dashboard/components/sidebar.tsx
@@ -38,7 +38,7 @@ export function Sidebar({
         ) : (
           Object.entries(grouped).map(([owner, ownerrepos]) => (
             <div key={owner}>
-              <p className="text-xs text-muted mb-2 px-1">{owner}</p>
+              <p className="text-xs text-muted mb-2 px-1 capitalize">{owner}</p>
               <div className="border-t border-border pt-2">
                 <ul className="space-y-0.5">
                   {ownerrepos.map(r => {

--- a/app/dashboard/components/stats.tsx
+++ b/app/dashboard/components/stats.tsx
@@ -1,9 +1,15 @@
 import type { LogEntry } from '@/app/lib/logging';
 
+function labelcount(log: LogEntry): number {
+  if (!log.labels) return 0;
+  return log.labels.length;
+}
+
 export function Stats({ logs }: { logs: LogEntry[] }) {
   const issues = logs.filter(l => l.type === 'issue').length;
   const prs = logs.filter(l => l.type === 'pr').length;
-  const labels = logs.reduce((acc, l) => acc + l.labels.length, 0);
+  const labels = logs.reduce((acc, l) => acc + labelcount(l), 0);
+  const skipped = logs.filter(l => l.skipped).length;
 
   const items = [
     { value: logs.length, label: 'TRIAGED', desc: 'Total' },
@@ -11,6 +17,10 @@ export function Stats({ logs }: { logs: LogEntry[] }) {
     { value: prs, label: 'PULL REQUESTS', desc: 'Labeled' },
     { value: labels, label: 'LABELS APPLIED', desc: 'Total' },
   ];
+
+  if (skipped > 0) {
+    items.push({ value: skipped, label: 'SKIPPED', desc: 'No labels' });
+  }
 
   return (
     <div className="grid grid-cols-2 lg:grid-cols-4 gap-px bg-border rounded-2xl overflow-hidden">

--- a/app/lib/logging.ts
+++ b/app/lib/logging.ts
@@ -2,14 +2,28 @@ import { redis } from './redis';
 
 const TTL = 60 * 60 * 24 * 30;
 
+export interface LabelDetail {
+  name: string;
+  reason: string;
+  color: string;
+}
+
 export interface LogEntry {
   type: 'issue' | 'pr';
   number: number;
   title: string;
-  labels: string[];
-  reasoning: string;
+  labels: LabelDetail[];
+  rejected: LabelDetail[];
+  confidence: 'high' | 'medium' | 'low';
+  summary: string;
   timestamp: number;
   repo: string;
+  model: string;
+  duration: number;
+  author: string;
+  url: string;
+  skipped: boolean;
+  available: number;
 }
 
 export async function writelog(


### PR DESCRIPTION
## summary
- per-label reasoning (why each label was applied)
- rejected labels (what AI considered but didn't pick)
- confidence level, model, duration, author, github link
- label colors from github repo
- skipped event tracking
- capitalize owner names in sidebar and subtitle
- backwards compatible with old log format