### PR TITLE
feat: dynamic tab titles

### DIFF
--- a/app/dashboard/[owner]/[repo]/layout.tsx
+++ b/app/dashboard/[owner]/[repo]/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ owner: string; repo: string }>;
+}): Promise<Metadata> {
+  const { repo } = await params;
+  return { title: `Tigent - ${repo.charAt(0).toUpperCase()}${repo.slice(1)}` };
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from 'next';
 import { Empty } from './components/empty';
+
+export const metadata: Metadata = {
+  title: 'Tigent - Dashboard',
+};
 
 export default function Page() {
   return <Empty hasrepos />;


### PR DESCRIPTION
## summary
- /dashboard shows "Tigent - Dashboard"
- /dashboard/owner/repo shows "Tigent - Repo"