### PR TITLE
fix: home icon returns to active repo

### DIFF
--- a/app/dashboard/components/header.tsx
+++ b/app/dashboard/components/header.tsx
@@ -45,7 +45,7 @@ export function Iconbar() {
       <div className="w-8 h-px bg-white/10 mb-2" />
 
       <a
-        href="/dashboard"
+        href={repo ? `/dashboard/${repo}` : '/dashboard'}
         className={`w-9 h-9 rounded-xl flex items-center justify-center transition-colors ${
           repo && !onconfig
             ? 'bg-white/10 text-white'


### PR DESCRIPTION
## summary
- home icon links to /dashboard/owner/repo when a repo is selected
- falls back to /dashboard when no repo is active