### PR TITLE
fix: config api uses installation token

### DIFF
--- a/app/api/dashboard/config/route.ts
+++ b/app/api/dashboard/config/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { getsession } from '@/app/lib/session';
-import { useroctokit } from '@/app/lib/github';
+import { getapp } from '@/app/lib/github';
 
 export async function GET(req: NextRequest) {
   const session = await getsession();
@@ -11,8 +11,11 @@ export async function GET(req: NextRequest) {
   const owner = req.nextUrl.searchParams.get('owner');
   if (!repo || !owner) return NextResponse.json(null);
 
-  const octokit = useroctokit(session.token);
   try {
+    const app = getapp();
+    const { data: installation } =
+      await app.octokit.rest.apps.getRepoInstallation({ owner, repo });
+    const octokit = await app.getInstallationOctokit(installation.id);
     const { data } = await octokit.rest.repos.getContent({
       owner,
       repo,


### PR DESCRIPTION
## summary
- config api now uses app installation token instead of user oauth token
- user oauth token doesn't have contents:read, installation token does