### PR TITLE
fix: installations api uses app token

### DIFF
--- a/app/api/dashboard/installations/route.ts
+++ b/app/api/dashboard/installations/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getsession } from '@/app/lib/session';
-import { useroctokit } from '@/app/lib/github';
+import { getapp } from '@/app/lib/github';
 
 export interface Repo {
   id: number;
@@ -13,25 +13,29 @@ export async function GET() {
   const session = await getsession();
   if (!session.token) return NextResponse.json([], { status: 401 });
 
-  const octokit = useroctokit(session.token);
-  const { data } =
-    await octokit.rest.apps.listInstallationsForAuthenticatedUser();
+  const app = getapp();
 
-  const repos: Repo[] = [];
-  for (const installation of data.installations) {
-    const { data: repodata } =
-      await octokit.rest.apps.listInstallationReposForAuthenticatedUser({
-        installation_id: installation.id,
-      });
-    for (const r of repodata.repositories) {
-      repos.push({
-        id: r.id,
-        name: r.name,
-        owner: r.owner.login,
-        installationid: installation.id,
-      });
+  try {
+    const repos: Repo[] = [];
+    for await (const {
+      installation,
+      octokit,
+    } of app.eachInstallation.iterator()) {
+      const { data } =
+        await octokit.rest.apps.listReposAccessibleToInstallation({
+          per_page: 100,
+        });
+      for (const r of data.repositories) {
+        repos.push({
+          id: r.id,
+          name: r.name,
+          owner: r.owner.login,
+          installationid: installation.id,
+        });
+      }
     }
+    return NextResponse.json(repos);
+  } catch {
+    return NextResponse.json([]);
   }
-
-  return NextResponse.json(repos);
 }


### PR DESCRIPTION
## summary
- installations api now uses app token instead of user oauth token
- user oauth token doesn't have permission to list installations
- iterates all app installations and their repos