### PR TITLE
fix: oauth scope and user token for dashboard apis

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -6,7 +6,7 @@ export async function GET(req: NextRequest) {
   const protocol = host.includes('localhost') ? 'http' : 'https';
   const params = new URLSearchParams({
     client_id: process.env.GITHUB_CLIENT_ID!,
-    scope: 'read:org',
+    scope: 'read:org repo',
     redirect_uri: `${protocol}://${host}/api/auth/callback`,
   });
   redirect(`https://github.com/login/oauth/authorize?${params}`);

--- a/app/api/dashboard/config/route.ts
+++ b/app/api/dashboard/config/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { getsession } from '@/app/lib/session';
-import { getapp } from '@/app/lib/github';
+import { useroctokit } from '@/app/lib/github';
 
 export async function GET(req: NextRequest) {
   const session = await getsession();
@@ -11,11 +11,8 @@ export async function GET(req: NextRequest) {
   const owner = req.nextUrl.searchParams.get('owner');
   if (!repo || !owner) return NextResponse.json(null);
 
+  const octokit = useroctokit(session.token);
   try {
-    const app = getapp();
-    const { data: installation } =
-      await app.octokit.rest.apps.getRepoInstallation({ owner, repo });
-    const octokit = await app.getInstallationOctokit(installation.id);
     const { data } = await octokit.rest.repos.getContent({
       owner,
       repo,

--- a/app/api/dashboard/installations/route.ts
+++ b/app/api/dashboard/installations/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getsession } from '@/app/lib/session';
-import { getapp } from '@/app/lib/github';
+import { useroctokit } from '@/app/lib/github';
 
 export interface Repo {
   id: number;
@@ -13,19 +13,18 @@ export async function GET() {
   const session = await getsession();
   if (!session.token) return NextResponse.json([], { status: 401 });
 
-  const app = getapp();
+  const octokit = useroctokit(session.token);
 
   try {
+    const { data } =
+      await octokit.rest.apps.listInstallationsForAuthenticatedUser();
     const repos: Repo[] = [];
-    for await (const {
-      installation,
-      octokit,
-    } of app.eachInstallation.iterator()) {
-      const { data } =
-        await octokit.rest.apps.listReposAccessibleToInstallation({
-          per_page: 100,
+    for (const installation of data.installations) {
+      const { data: repodata } =
+        await octokit.rest.apps.listInstallationReposForAuthenticatedUser({
+          installation_id: installation.id,
         });
-      for (const r of data.repositories) {
+      for (const r of repodata.repositories) {
         repos.push({
           id: r.id,
           name: r.name,


### PR DESCRIPTION
## summary
- add repo scope to oauth login so user token can read repos
- revert installations and config apis back to user token
- user token is better for security (scoped to user's access)