### PR TITLE
feat: server-side data fetching and navigation fixes

### DIFF
--- a/app/api/dashboard/installations/route.ts
+++ b/app/api/dashboard/installations/route.ts
@@ -1,40 +1,11 @@
 import { NextResponse } from 'next/server';
 import { getsession } from '@/app/lib/session';
-import { useroctokit } from '@/app/lib/github';
-
-export interface Repo {
-  id: number;
-  name: string;
-  owner: string;
-  installationid: number;
-}
+import { fetchrepos } from '@/app/lib/github';
 
 export async function GET() {
   const session = await getsession();
   if (!session.token) return NextResponse.json([], { status: 401 });
 
-  const octokit = useroctokit(session.token);
-
-  try {
-    const { data } =
-      await octokit.rest.apps.listInstallationsForAuthenticatedUser();
-    const repos: Repo[] = [];
-    for (const installation of data.installations) {
-      const { data: repodata } =
-        await octokit.rest.apps.listInstallationReposForAuthenticatedUser({
-          installation_id: installation.id,
-        });
-      for (const r of repodata.repositories) {
-        repos.push({
-          id: r.id,
-          name: r.name,
-          owner: r.owner.login,
-          installationid: installation.id,
-        });
-      }
-    }
-    return NextResponse.json(repos);
-  } catch {
-    return NextResponse.json([]);
-  }
+  const repos = await fetchrepos(session.token);
+  return NextResponse.json(repos);
 }

--- a/app/dashboard/[owner]/[repo]/config/page.tsx
+++ b/app/dashboard/[owner]/[repo]/config/page.tsx
@@ -1,19 +1,42 @@
-'use client';
-
-import { useParams } from 'next/navigation';
+import { getsession } from '@/app/lib/session';
+import { useroctokit } from '@/app/lib/github';
 import { Config } from '../../../components/config';
 
-export default function Page() {
-  const params = useParams<{ owner: string; repo: string }>();
-  const full = `${params.owner}/${params.repo}`;
+async function fetchconfig(token: string, owner: string, repo: string) {
+  const octokit = useroctokit(token);
+  try {
+    const { data } = await octokit.rest.repos.getContent({
+      owner,
+      repo,
+      path: '.github/tigent.yml',
+      mediaType: { format: 'raw' },
+    });
+    return data as unknown as string;
+  } catch {
+    return null;
+  }
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ owner: string; repo: string }>;
+}) {
+  const { owner, repo } = await params;
+  const session = await getsession();
+  const content = session.token
+    ? await fetchconfig(session.token, owner, repo)
+    : null;
 
   return (
     <div className="p-5 md:p-10 space-y-6 md:space-y-8 min-w-0">
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Configuration</h1>
-        <p className="text-muted mt-1 capitalize">{full}</p>
+        <p className="text-muted mt-1 capitalize">
+          {owner}/{repo}
+        </p>
       </div>
-      <Config repo={params.repo} owner={params.owner} />
+      <Config content={content} />
     </div>
   );
 }

--- a/app/dashboard/[owner]/[repo]/loading.tsx
+++ b/app/dashboard/[owner]/[repo]/loading.tsx
@@ -1,0 +1,44 @@
+export default function Loading() {
+  return (
+    <div className="p-5 md:p-10 space-y-6 md:space-y-8 min-w-0 animate-pulse">
+      <div>
+        <div className="bg-warm rounded-lg h-9 w-36" />
+        <div className="bg-warm rounded-md h-5 w-24 mt-1" />
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-px bg-border rounded-2xl overflow-hidden">
+        {[1, 2, 3, 4].map(i => (
+          <div key={i} className="bg-bg p-4 md:p-6">
+            <div className="bg-warm rounded-md h-9 w-12" />
+            <div className="bg-warm rounded-md h-3 w-20 mt-2" />
+            <div className="bg-warm rounded-md h-3.5 w-10 mt-1.5" />
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <div className="bg-warm rounded-md h-6 w-32 mb-4" />
+        <div className="border border-border rounded-2xl overflow-hidden divide-y divide-border">
+          {[0.6, 0.8, 0.5, 0.7, 0.45].map((w, i) => (
+            <div
+              key={i}
+              className="px-4 md:px-5 py-3 md:py-4 flex items-center gap-2 md:gap-3"
+            >
+              <div className="hidden md:block bg-warm rounded-md h-4 w-14" />
+              <div className="bg-warm rounded-md h-4 w-8 shrink-0" />
+              <div
+                className="bg-warm rounded-md h-4 flex-1"
+                style={{ maxWidth: `${w * 100}%` }}
+              />
+              <div className="hidden md:flex gap-1.5 shrink-0">
+                <div className="bg-warm rounded-full h-5 w-14" />
+                <div className="bg-warm rounded-full h-5 w-10" />
+              </div>
+              <div className="bg-warm rounded-md h-3 w-8 shrink-0" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/[owner]/[repo]/page.tsx
+++ b/app/dashboard/[owner]/[repo]/page.tsx
@@ -1,11 +1,14 @@
-'use client';
-
-import { useParams } from 'next/navigation';
+import { readlogs } from '@/app/lib/logging';
 import { Activity } from '../../components/activity';
 
-export default function Page() {
-  const params = useParams<{ owner: string; repo: string }>();
-  const full = `${params.owner}/${params.repo}`;
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ owner: string; repo: string }>;
+}) {
+  const { owner, repo } = await params;
+  const full = `${owner}/${repo}`;
+  const logs = await readlogs(full);
 
   return (
     <div className="p-5 md:p-10 space-y-6 md:space-y-8 min-w-0">
@@ -13,7 +16,7 @@ export default function Page() {
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
         <p className="text-muted mt-1 capitalize">{full}</p>
       </div>
-      <Activity repo={full} />
+      <Activity logs={logs} />
     </div>
   );
 }

--- a/app/dashboard/components/activity.tsx
+++ b/app/dashboard/components/activity.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { LogEntry } from '@/app/lib/logging';
 import { Stats } from './stats';
 
@@ -44,37 +44,8 @@ function labeldata(log: LogEntry): { name: string; color: string }[] {
   return log.labels.map(l => ({ name: l.name, color: l.color || '' }));
 }
 
-export function Activity({ repo }: { repo: string }) {
-  const [logs, setLogs] = useState<LogEntry[]>([]);
-  const [loading, setLoading] = useState(true);
+export function Activity({ logs }: { logs: LogEntry[] }) {
   const [expanded, setExpanded] = useState<string | null>(null);
-
-  useEffect(() => {
-    setLoading(true);
-    setExpanded(null);
-    fetch(`/api/dashboard/logs?repo=${encodeURIComponent(repo)}`)
-      .then(r => r.json())
-      .then(data => {
-        setLogs(data);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
-  }, [repo]);
-
-  if (loading) {
-    return (
-      <div className="space-y-4">
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-          {[1, 2, 3, 4].map(i => (
-            <div key={i} className="bg-warm rounded-2xl h-24 animate-pulse" />
-          ))}
-        </div>
-        {[1, 2, 3].map(i => (
-          <div key={i} className="bg-warm rounded-2xl h-20 animate-pulse" />
-        ))}
-      </div>
-    );
-  }
 
   return (
     <div className="space-y-8">
@@ -166,7 +137,7 @@ export function Activity({ repo }: { repo: string }) {
                   )}
 
                   {open && (
-                    <div className="mt-4 md:ml-[6.5rem] space-y-4">
+                    <div className="mt-4 md:ml-[4.25rem] space-y-4">
                       {log.summary && (
                         <p className="text-sm text-fg/80">{log.summary}</p>
                       )}

--- a/app/dashboard/components/config.tsx
+++ b/app/dashboard/components/config.tsx
@@ -1,34 +1,10 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-
 function indent(line: string) {
   const trimmed = line.replace(/^ +/, '');
   const spaces = line.length - trimmed.length;
   return { text: trimmed, pad: spaces * 0.6 };
 }
 
-export function Config({ repo, owner }: { repo: string; owner: string }) {
-  const [content, setContent] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    setLoading(true);
-    fetch(
-      `/api/dashboard/config?repo=${encodeURIComponent(repo)}&owner=${encodeURIComponent(owner)}`,
-    )
-      .then(r => r.json())
-      .then(data => {
-        setContent(data.content);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
-  }, [repo, owner]);
-
-  if (loading) {
-    return <div className="bg-warm rounded-2xl h-24 animate-pulse" />;
-  }
-
+export function Config({ content }: { content: string | null }) {
   const lines = content ? content.split('\n') : [];
 
   return (

--- a/app/dashboard/components/header.tsx
+++ b/app/dashboard/components/header.tsx
@@ -2,9 +2,14 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
+import Link from 'next/link';
 
-export function Iconbar() {
-  const [user, setUser] = useState({ username: '', avatar: '' });
+interface User {
+  username: string;
+  avatar: string;
+}
+
+export function Iconbar({ user }: { user: User }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
@@ -12,13 +17,6 @@ export function Iconbar() {
   const parts = pathname.split('/').filter(Boolean);
   const repo = parts.length >= 3 ? `${parts[1]}/${parts[2]}` : null;
   const onconfig = pathname.endsWith('/config');
-
-  useEffect(() => {
-    fetch('/api/auth/session')
-      .then(r => r.json())
-      .then(data => setUser(data))
-      .catch(() => {});
-  }, []);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -44,7 +42,7 @@ export function Iconbar() {
 
       <div className="w-8 h-px bg-white/10 mb-2" />
 
-      <a
+      <Link
         href={repo ? `/dashboard/${repo}` : '/dashboard'}
         className={`w-9 h-9 rounded-xl flex items-center justify-center transition-colors ${
           repo && !onconfig
@@ -67,8 +65,8 @@ export function Iconbar() {
             strokeLinejoin="round"
           />
         </svg>
-      </a>
-      <a
+      </Link>
+      <Link
         href={repo ? `/dashboard/${repo}/config` : '/dashboard'}
         className={`w-9 h-9 rounded-xl flex items-center justify-center transition-colors ${
           onconfig
@@ -96,7 +94,7 @@ export function Iconbar() {
             strokeLinejoin="round"
           />
         </svg>
-      </a>
+      </Link>
 
       <div className="mt-auto flex flex-col items-center gap-1">
         <a
@@ -137,56 +135,50 @@ export function Iconbar() {
         <div className="w-8 h-px bg-white/10 my-2" />
 
         <div className="relative" ref={ref}>
-          {user.avatar ? (
-            <>
-              <button
-                type="button"
-                onClick={() => setOpen(!open)}
-                className="rounded-full transition-opacity hover:opacity-80"
-              >
+          <button
+            type="button"
+            onClick={() => setOpen(!open)}
+            className="rounded-full transition-opacity hover:opacity-80"
+          >
+            <img
+              src={user.avatar}
+              alt=""
+              className="w-8 h-8 rounded-full ring-2 ring-white/10"
+            />
+          </button>
+          {open && (
+            <div className="absolute -bottom-5 left-12 bg-fg text-bg rounded-2xl shadow-2xl py-3 px-1 min-w-[180px] z-50">
+              <div className="flex items-center gap-3 px-3 pb-3 border-b border-white/10">
                 <img
                   src={user.avatar}
                   alt=""
-                  className="w-8 h-8 rounded-full ring-2 ring-white/10"
+                  className="w-8 h-8 rounded-full"
                 />
-              </button>
-              {open && (
-                <div className="absolute -bottom-5 left-12 bg-fg text-bg rounded-2xl shadow-2xl py-3 px-1 min-w-[180px] z-50">
-                  <div className="flex items-center gap-3 px-3 pb-3 border-b border-white/10">
-                    <img
-                      src={user.avatar}
-                      alt=""
-                      className="w-8 h-8 rounded-full"
-                    />
-                    <span className="text-sm font-medium text-white">
-                      {user.username}
-                    </span>
-                  </div>
-                  <a
-                    href="/api/auth/logout"
-                    className="flex items-center gap-2 mt-1 px-3 py-2.5 text-sm text-white/60 hover:text-white hover:bg-white/5 transition-colors rounded-xl"
-                  >
-                    <svg
-                      className="w-4 h-4"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      aria-hidden="true"
-                    >
-                      <path
-                        d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      />
-                    </svg>
-                    Logout
-                  </a>
-                </div>
-              )}
-            </>
-          ) : (
-            <div className="w-8 h-8 rounded-full bg-white/10 animate-pulse" />
+                <span className="text-sm font-medium text-white">
+                  {user.username}
+                </span>
+              </div>
+              <a
+                href="/api/auth/logout"
+                className="flex items-center gap-2 mt-1 px-3 py-2.5 text-sm text-white/60 hover:text-white hover:bg-white/5 transition-colors rounded-xl"
+              >
+                <svg
+                  className="w-4 h-4"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                Logout
+              </a>
+            </div>
           )}
         </div>
       </div>

--- a/app/dashboard/components/mobilenav.tsx
+++ b/app/dashboard/components/mobilenav.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
-import type { Repo } from '@/app/api/dashboard/installations/route';
+import type { Repo } from '@/app/lib/github';
 
 export function Mobilenav({
   repos,

--- a/app/dashboard/components/shell.tsx
+++ b/app/dashboard/components/shell.tsx
@@ -1,34 +1,34 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
-import type { Repo } from '@/app/api/dashboard/installations/route';
+import type { Repo } from '@/app/lib/github';
 import { Iconbar } from './header';
 import { Sidebar } from './sidebar';
 import { Mobilenav } from './mobilenav';
 
-export function Shell({ children }: { children: React.ReactNode }) {
-  const [repos, setRepos] = useState<Repo[]>([]);
-  const [loading, setLoading] = useState(true);
-  const pathname = usePathname();
+interface User {
+  username: string;
+  avatar: string;
+}
 
-  useEffect(() => {
-    fetch('/api/dashboard/installations')
-      .then(r => r.json())
-      .then((data: Repo[]) => {
-        setRepos(data);
-        setLoading(false);
-      })
-      .catch(() => setLoading(false));
-  }, []);
+export function Shell({
+  children,
+  repos,
+  user,
+}: {
+  children: React.ReactNode;
+  repos: Repo[];
+  user: User;
+}) {
+  const pathname = usePathname();
 
   const parts = pathname.split('/').filter(Boolean);
   const selected = parts.length >= 3 ? `${parts[1]}/${parts[2]}` : null;
   return (
     <>
       <div className="hidden md:contents">
-        <Iconbar />
-        <Sidebar repos={repos} selected={selected} loading={loading} />
+        <Iconbar user={user} />
+        <Sidebar repos={repos} selected={selected} />
       </div>
       <div className="md:hidden flex flex-col flex-1 min-w-0">
         <main className="flex-1 min-w-0 bg-bg rounded-2xl overflow-y-auto overflow-x-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden pb-16">

--- a/app/dashboard/components/sidebar.tsx
+++ b/app/dashboard/components/sidebar.tsx
@@ -1,14 +1,12 @@
 import Link from 'next/link';
-import type { Repo } from '@/app/api/dashboard/installations/route';
+import type { Repo } from '@/app/lib/github';
 
 export function Sidebar({
   repos,
   selected,
-  loading,
 }: {
   repos: Repo[];
   selected: string | null;
-  loading: boolean;
 }) {
   const grouped: Record<string, Repo[]> = {};
   for (const r of repos) {
@@ -19,13 +17,7 @@ export function Sidebar({
   return (
     <div className="w-56 shrink-0 bg-bg rounded-2xl overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
       <div className="p-5 space-y-6">
-        {loading ? (
-          <div className="space-y-2 pt-2">
-            {[1, 2, 3].map(i => (
-              <div key={i} className="bg-warm rounded-lg h-10 animate-pulse" />
-            ))}
-          </div>
-        ) : repos.length === 0 ? (
+        {repos.length === 0 ? (
           <div className="space-y-3 pt-2">
             <p className="text-sm text-muted">No repos</p>
             <a

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 import { getsession } from '@/app/lib/session';
+import { fetchrepos } from '@/app/lib/github';
 import { Shell } from './components/shell';
 
 export default async function Layout({
@@ -10,9 +11,14 @@ export default async function Layout({
   const session = await getsession();
   if (!session.token) redirect('/login');
 
+  const repos = await fetchrepos(session.token);
+  const user = { username: session.username, avatar: session.avatar };
+
   return (
     <div className="h-screen bg-warm flex overflow-hidden p-0 md:p-3 gap-0 md:gap-3">
-      <Shell>{children}</Shell>
+      <Shell repos={repos} user={user}>
+        {children}
+      </Shell>
     </div>
   );
 }

--- a/app/lib/github.ts
+++ b/app/lib/github.ts
@@ -15,3 +15,41 @@ export function getapp() {
 export function useroctokit(token: string) {
   return new Octokit({ auth: token });
 }
+
+export interface Repo {
+  id: number;
+  name: string;
+  owner: string;
+  installationid: number;
+}
+
+export async function fetchrepos(token: string): Promise<Repo[]> {
+  const octokit = useroctokit(token);
+  try {
+    const { data } =
+      await octokit.rest.apps.listInstallationsForAuthenticatedUser();
+    const results = await Promise.all(
+      data.installations.map(i =>
+        octokit.rest.apps
+          .listInstallationReposForAuthenticatedUser({
+            installation_id: i.id,
+          })
+          .then(res => ({ installation: i, repos: res.data.repositories })),
+      ),
+    );
+    const repos: Repo[] = [];
+    for (const { installation, repos: repolist } of results) {
+      for (const r of repolist) {
+        repos.push({
+          id: r.id,
+          name: r.name,
+          owner: r.owner.login,
+          installationid: installation.id,
+        });
+      }
+    }
+    return repos;
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## summary
- move all data fetching from client useEffect to server components (layout, pages)
- use next/link for iconbar navigation to prevent full page reloads
- parallelize installation repo fetching with promise.all
- align expanded activity content with # in pr number
- add loading.tsx skeleton matching real page structure
- remove all client loading states (sidebar, iconbar, activity, config)
- config component no longer needs 'use client'
- shared fetchrepos function and repo type in lib/github.ts