### PR TITLE
fix: restore dashboard auth refresh

### DIFF
--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from 'next/server';
+import { redirect } from 'next/navigation';
+import { token } from '@/app/lib/oauth';
+import { getsession } from '@/app/lib/session';
+
+function path(value: string | null) {
+  if (!value || !value.startsWith('/')) return '/dashboard';
+  return value;
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getsession();
+  const next = path(req.nextUrl.searchParams.get('next'));
+  const value = await token(session);
+  if (!value) {
+    session.destroy();
+    redirect('/login');
+  }
+  redirect(next);
+}

--- a/app/dashboard/[owner]/[repo]/config/page.tsx
+++ b/app/dashboard/[owner]/[repo]/config/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation';
 import { Autherror } from '@/app/lib/github';
-import { token } from '@/app/lib/oauth';
+import { peek, stale } from '@/app/lib/oauth';
 import { readconfig } from '@/app/lib/repos';
 import { getsession } from '@/app/lib/session';
 import { Config } from '../../../components/config';
@@ -12,7 +12,11 @@ export default async function Page({
 }) {
   const { owner, repo } = await params;
   const session = await getsession();
-  const value = await token(session);
+  const next = `/dashboard/${owner}/${repo}/config`;
+  if (stale(session))
+    redirect(`/api/auth/refresh?next=${encodeURIComponent(next)}`);
+  const value = peek(session);
+  if (!value) redirect('/login');
 
   try {
     const content = value ? await readconfig(value, owner, repo) : null;
@@ -47,7 +51,6 @@ export default async function Page({
     );
   } catch (error) {
     if (!(error instanceof Autherror)) throw error;
-    session.destroy();
-    redirect('/login');
+    redirect(`/api/auth/refresh?next=${encodeURIComponent(next)}`);
   }
 }

--- a/app/dashboard/[owner]/[repo]/page.tsx
+++ b/app/dashboard/[owner]/[repo]/page.tsx
@@ -4,7 +4,7 @@ import { parseconfig } from '@/app/lib/config';
 import { counts, readlogs } from '@/app/lib/logging';
 import { readmemory } from '@/app/lib/memory';
 import { label } from '@/app/lib/model';
-import { token } from '@/app/lib/oauth';
+import { peek, stale } from '@/app/lib/oauth';
 import { readconfig } from '@/app/lib/repos';
 import { getsession } from '@/app/lib/session';
 import { Autherror } from '@/app/lib/github';
@@ -19,7 +19,11 @@ export default async function Page({
   const { owner, repo } = await params;
   const full = `${owner}/${repo}`;
   const session = await getsession();
-  const value = await token(session);
+  const next = `/dashboard/${owner}/${repo}`;
+  if (stale(session))
+    redirect(`/api/auth/refresh?next=${encodeURIComponent(next)}`);
+  const value = peek(session);
+  if (!value) redirect('/login');
 
   try {
     const [logs, stats, items, content] = await Promise.all([
@@ -96,7 +100,6 @@ export default async function Page({
     );
   } catch (error) {
     if (!(error instanceof Autherror)) throw error;
-    session.destroy();
-    redirect('/login');
+    redirect(`/api/auth/refresh?next=${encodeURIComponent(next)}`);
   }
 }

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
-import { token } from '@/app/lib/oauth';
+import { peek, stale } from '@/app/lib/oauth';
 import { getsession } from '@/app/lib/session';
 import { Autherror, fetchrepos } from '@/app/lib/github';
 import { Shell } from './components/shell';
@@ -10,7 +10,8 @@ export default async function Layout({
   children: React.ReactNode;
 }) {
   const session = await getsession();
-  const value = await token(session);
+  if (stale(session)) redirect('/api/auth/refresh?next=/dashboard');
+  const value = peek(session);
   if (!value) redirect('/login');
 
   try {
@@ -29,7 +30,6 @@ export default async function Layout({
     );
   } catch (error) {
     if (!(error instanceof Autherror)) throw error;
-    session.destroy();
-    redirect('/login');
+    redirect('/api/auth/refresh?next=/dashboard');
   }
 }

--- a/app/lib/oauth.ts
+++ b/app/lib/oauth.ts
@@ -132,3 +132,12 @@ export async function token(session?: Store) {
   await value.save();
   return value.token || null;
 }
+
+export function peek(session: Store) {
+  if (!session.token || due(session)) return null;
+  return session.token;
+}
+
+export function stale(session: Store) {
+  return Boolean(session.token) && due(session);
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
-import { token } from '@/app/lib/oauth';
+import { peek, stale } from '@/app/lib/oauth';
 import { getsession } from '@/app/lib/session';
 
 function seededrandom(seed: number) {
@@ -14,7 +14,8 @@ const grid = Array.from({ length: 12 * 20 }).map((_, i) => {
 
 export default async function Page() {
   const session = await getsession();
-  if (await token(session)) redirect('/dashboard');
+  if (stale(session)) redirect('/api/auth/refresh?next=/dashboard');
+  if (peek(session)) redirect('/dashboard');
 
   return (
     <div className="h-screen bg-fg flex items-center justify-center relative overflow-hidden">


### PR DESCRIPTION
## summary
- stop mutating cookies during server component renders
- refresh or clear dashboard auth through a route handler instead
- restore dashboard login redirects without crashing the page