### PR TITLE
fix: avoid dashboard refresh redirect loop

### DIFF
--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from 'next/server';
-import { redirect } from 'next/navigation';
+import { NextResponse } from 'next/server';
 import { token } from '@/app/lib/oauth';
 import { getsession } from '@/app/lib/session';
 
@@ -12,9 +12,10 @@ export async function GET(req: NextRequest) {
   const session = await getsession();
   const next = path(req.nextUrl.searchParams.get('next'));
   const value = await token(session);
+  const headers = { 'Cache-Control': 'no-store' };
   if (!value) {
     session.destroy();
-    redirect('/login');
+    return NextResponse.redirect(new URL('/login', req.url), { headers });
   }
-  redirect(next);
+  return NextResponse.redirect(new URL(next, req.url), { headers });
 }


### PR DESCRIPTION
## summary
- return refresh redirects from the route handler response
- keep cookie writes and redirects in the same auth refresh request
- stop the dashboard from bouncing between /dashboard and /api/auth/refresh