### PR TITLE
fix: polish dashboard auth recovery

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,11 +1,16 @@
 import type { NextRequest } from 'next/server';
-import { redirect } from 'next/navigation';
+import { NextResponse } from 'next/server';
 import { callback } from '@/app/lib/oauth';
 import { getsession } from '@/app/lib/session';
 
 export async function GET(req: NextRequest) {
   const token = await callback(req);
-  if (!token) redirect('/login');
+  const headers = { 'Cache-Control': 'no-store' };
+  if (!token) {
+    return NextResponse.redirect(new URL('/login?reason=auth', req.url), {
+      headers,
+    });
+  }
 
   const userres = await fetch('https://api.github.com/user', {
     headers: { Authorization: `Bearer ${token}` },
@@ -13,7 +18,9 @@ export async function GET(req: NextRequest) {
   if (!userres.ok) {
     const session = await getsession();
     session.destroy();
-    redirect('/login');
+    return NextResponse.redirect(new URL('/login?reason=auth', req.url), {
+      headers,
+    });
   }
 
   const user = await userres.json();
@@ -24,5 +31,5 @@ export async function GET(req: NextRequest) {
   session.id = user.id;
   await session.save();
 
-  redirect('/dashboard');
+  return NextResponse.redirect(new URL('/dashboard', req.url), { headers });
 }

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,7 +1,9 @@
 import type { NextRequest } from 'next/server';
-import { redirect } from 'next/navigation';
+import { NextResponse } from 'next/server';
 import { login } from '@/app/lib/oauth';
 
 export async function GET(req: NextRequest) {
-  redirect(await login(req));
+  return NextResponse.redirect(await login(req), {
+    headers: { 'Cache-Control': 'no-store' },
+  });
 }

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,8 +1,11 @@
-import { redirect } from 'next/navigation';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 import { getsession } from '@/app/lib/session';
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   const session = await getsession();
   session.destroy();
-  redirect('/');
+  return NextResponse.redirect(new URL('/', req.url), {
+    headers: { 'Cache-Control': 'no-store' },
+  });
 }

--- a/app/api/auth/refresh/route.ts
+++ b/app/api/auth/refresh/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from 'next/server';
-import { redirect } from 'next/navigation';
+import { NextResponse } from 'next/server';
 import { token } from '@/app/lib/oauth';
 import { getsession } from '@/app/lib/session';
 
@@ -12,9 +12,12 @@ export async function GET(req: NextRequest) {
   const session = await getsession();
   const next = path(req.nextUrl.searchParams.get('next'));
   const value = await token(session);
+  const headers = { 'Cache-Control': 'no-store' };
   if (!value) {
     session.destroy();
-    redirect('/login');
+    return NextResponse.redirect(new URL('/login?reason=expired', req.url), {
+      headers,
+    });
   }
-  redirect(next);
+  return NextResponse.redirect(new URL(next, req.url), { headers });
 }

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -4,11 +4,15 @@ import { getsession } from '@/app/lib/session';
 
 export async function GET() {
   const session = await getsession();
+  const headers = { 'Cache-Control': 'no-store' };
   if (!(await token(session))) {
-    return NextResponse.json({ username: '', avatar: '' });
+    return NextResponse.json({ username: '', avatar: '' }, { headers });
   }
-  return NextResponse.json({
-    username: session.username || '',
-    avatar: session.avatar || '',
-  });
+  return NextResponse.json(
+    {
+      username: session.username || '',
+      avatar: session.avatar || '',
+    },
+    { headers },
+  );
 }

--- a/app/api/dashboard/config/route.ts
+++ b/app/api/dashboard/config/route.ts
@@ -7,21 +7,22 @@ import { Autherror } from '@/app/lib/github';
 
 export async function GET(req: NextRequest) {
   const session = await getsession();
+  const headers = { 'Cache-Control': 'no-store' };
   const value = await token(session);
-  if (!value) return NextResponse.json(null, { status: 401 });
+  if (!value) return NextResponse.json(null, { status: 401, headers });
 
   const repo = req.nextUrl.searchParams.get('repo');
   const owner = req.nextUrl.searchParams.get('owner');
-  if (!repo || !owner) return NextResponse.json(null);
+  if (!repo || !owner) return NextResponse.json(null, { headers });
 
   try {
     const content = await readconfig(value, owner, repo);
-    return NextResponse.json({ content });
+    return NextResponse.json({ content }, { headers });
   } catch (error) {
     if (error instanceof Autherror) {
       session.destroy();
-      return NextResponse.json(null, { status: 401 });
+      return NextResponse.json(null, { status: 401, headers });
     }
-    return NextResponse.json({ content: null });
+    return NextResponse.json({ content: null }, { headers });
   }
 }

--- a/app/api/dashboard/installations/route.ts
+++ b/app/api/dashboard/installations/route.ts
@@ -5,15 +5,16 @@ import { Autherror, fetchrepos } from '@/app/lib/github';
 
 export async function GET() {
   const session = await getsession();
+  const headers = { 'Cache-Control': 'no-store' };
   const value = await token(session);
-  if (!value) return NextResponse.json([], { status: 401 });
+  if (!value) return NextResponse.json([], { status: 401, headers });
 
   try {
     const repos = await fetchrepos(value);
-    return NextResponse.json(repos);
+    return NextResponse.json(repos, { headers });
   } catch (error) {
     if (!(error instanceof Autherror)) throw error;
     session.destroy();
-    return NextResponse.json([], { status: 401 });
+    return NextResponse.json([], { status: 401, headers });
   }
 }

--- a/app/api/dashboard/logs/route.ts
+++ b/app/api/dashboard/logs/route.ts
@@ -6,15 +6,18 @@ import { readlogs } from '@/app/lib/logging';
 
 export async function GET(req: NextRequest) {
   const session = await getsession();
-  if (!(await token(session))) return NextResponse.json([], { status: 401 });
+  const headers = { 'Cache-Control': 'no-store' };
+  if (!(await token(session))) {
+    return NextResponse.json([], { status: 401, headers });
+  }
 
   const repo = req.nextUrl.searchParams.get('repo');
-  if (!repo) return NextResponse.json([]);
+  if (!repo) return NextResponse.json([], { headers });
 
   const limit = Number.parseInt(
     req.nextUrl.searchParams.get('limit') || '100',
     10,
   );
   const logs = await readlogs(repo, 0, Number.isNaN(limit) ? 100 : limit);
-  return NextResponse.json(logs);
+  return NextResponse.json(logs, { headers });
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -12,10 +12,26 @@ const grid = Array.from({ length: 12 * 20 }).map((_, i) => {
   return r > 0.85 ? Math.round(r * 100) / 100 : 0;
 });
 
-export default async function Page() {
+function message(value?: string) {
+  if (value === 'expired') {
+    return 'your github session expired. sign in again to reload your repos.';
+  }
+  if (value === 'auth') {
+    return 'github sign-in failed. try again.';
+  }
+  return '';
+}
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ reason?: string }>;
+}) {
   const session = await getsession();
+  const params = await searchParams;
   if (stale(session)) redirect('/api/auth/refresh?next=/dashboard');
   if (peek(session)) redirect('/dashboard');
+  const notice = message(params.reason);
 
   return (
     <div className="h-screen bg-fg flex items-center justify-center relative overflow-hidden">
@@ -52,6 +68,11 @@ export default async function Page() {
         <p className="text-white/40 text-center mb-10 max-w-sm">
           See activity, manage repos, and review labeling decisions
         </p>
+        {notice ? (
+          <p className="mb-6 max-w-sm rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-center text-sm text-white/70">
+            {notice}
+          </p>
+        ) : null}
 
         <a
           href="/api/auth/login"


### PR DESCRIPTION
## summary
- return explicit no-store responses from auth and dashboard session routes
- show a clear login message when github auth expires or fails
- keep auth redirects inside route handler responses for more reliable session updates